### PR TITLE
Bsp: increase limits

### DIFF
--- a/modules/PhyVersoBSP/connector_1/evse_board_supportImpl.cpp
+++ b/modules/PhyVersoBSP/connector_1/evse_board_supportImpl.cpp
@@ -11,7 +11,7 @@ void evse_board_supportImpl::init() {
         std::scoped_lock lock(caps_mutex);
 
         caps.min_current_A_import = mod->config.caps_min_current_A;
-        caps.max_current_A_import = 6;
+        caps.max_current_A_import = 16;
         caps.min_phase_count_import = 1;
         caps.max_phase_count_import = 3;
         caps.supports_changing_phases_during_charging = false;

--- a/modules/PhyVersoBSP/connector_2/evse_board_supportImpl.cpp
+++ b/modules/PhyVersoBSP/connector_2/evse_board_supportImpl.cpp
@@ -11,7 +11,7 @@ void evse_board_supportImpl::init() {
         std::scoped_lock lock(caps_mutex);
 
         caps.min_current_A_import = mod->config.caps_min_current_A;
-        caps.max_current_A_import = 6;
+        caps.max_current_A_import = 16;
         caps.min_phase_count_import = 1;
         caps.max_phase_count_import = 3;
         caps.supports_changing_phases_during_charging = false;


### PR DESCRIPTION
Currently the bsp has hard coded the limit to 6 amps - we move it to 16A for now