### PR TITLE
Add timestamp to SessionFinished events

### DIFF
--- a/modules/EvseManager/evse/evse_managerImpl.cpp
+++ b/modules/EvseManager/evse/evse_managerImpl.cpp
@@ -169,12 +169,16 @@ void evse_managerImpl::ready() {
 
             se.session_started = session_started;
         } else if (e == types::evse_manager::SessionEventEnum::SessionFinished) {
+            types::evse_manager::SessionFinished session_finished;
+            session_finished.timestamp =
+                date::format("%FT%TZ", std::chrono::time_point_cast<std::chrono::milliseconds>(date::utc_clock::now()));
             session_log.evse(false, fmt::format("Session Finished"));
             session_log.stopSession();
             mod->telemetry.publish("session", "events",
                                    {{"timestamp", Everest::Date::to_rfc3339(date::utc_clock::now())},
                                     {"type", "session_finished"},
                                     {"session_id", session_uuid}});
+            se.session_finished = session_finished;
         } else if (e == types::evse_manager::SessionEventEnum::TransactionStarted) {
             types::evse_manager::TransactionStarted transaction_started;
             transaction_started.timestamp =

--- a/types/evse_manager.yaml
+++ b/types/evse_manager.yaml
@@ -157,6 +157,17 @@ types:
           Filenames should start with "incomplete-" when they are not finished yet,
           this allows other process to wait for the completion after the SessionFinished event.
         type: string
+  SessionFinished:
+    description: Data for the SessionFinished event
+    type: object
+    additionalProperties: false
+    required:
+      - timestamp
+    properties:
+      timestamp:
+        description: Session start time in RFC3339 format
+        type: string
+        format: date-time   
   TransactionStarted:
     description: Data for the TransactionStarted event
     type: object
@@ -315,6 +326,10 @@ types:
         description: data for SessionStarted event
         type: object
         $ref: /evse_manager#/SessionStarted
+      session_finished:
+        description: data for the SessionFinished event
+        type: object
+        $ref: /evse_manager#/SessionFinished
       transaction_started:
         description: data for TransactionStarted event
         type: object


### PR DESCRIPTION
Up until now the `SessionFinished` events had no timestamp. Has a hack, the RsQcpp module was using `TransactionFinished` to mark the end of a session, since that one has a timestamp.

This PR adds a specific `session_finished` property to the SessionEvent type which just contains a timestamp.

PS: I will create the same PR in the upstream repo, but lets get this in case that one stays open for a while.