### PR TITLE
EvseManager: Turn pwm off before finishing transaction on remote stop

### DIFF
--- a/modules/EvseManager/Charger.cpp
+++ b/modules/EvseManager/Charger.cpp
@@ -1022,6 +1022,11 @@ bool Charger::cancelTransaction(const types::evse_manager::StopTransactionReques
             currentState = EvseState::ChargingPausedEVSE;
         }
 
+        // FIXME(evgeny): We disable pwm here since we need to get signed meter values.
+        // Maybe state machine should be refactored and cancelTransaction should trigger
+        // transition to EvseState::Finished, with active transaction.
+        // This way, the signed meter values will be retrieved there.
+        pwm_off();
         transaction_active = false;
         last_stop_transaction_reason = request.reason;
         stop_transaction_id_tag.clear();


### PR DESCRIPTION
The `cancelTransactioin` handler now is responsible for stopping the entire transaction, without intermediate events.

We need to do pwm_off there.

PS. Ideally, we would transition to a dedicated state for signing meter values.