### PR TITLE
fix(EvseManager): Signal HLC to resume charging on resume_charging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ __pycache__/
 *.orig
 *.rej
 docs/source/conf.py
+
+# Gas Town infrastructure
+.beads/
+.runtime/
+.claude/
+.logs/

--- a/modules/EVSE/EvseManager/Charger.cpp
+++ b/modules/EVSE/EvseManager/Charger.cpp
@@ -1137,6 +1137,7 @@ bool Charger::resume_charging() {
 
     if (shared_context.hlc_charging_active and shared_context.transaction_active and
         shared_context.current_state == EvseState::ChargingPausedEVSE) {
+        signal_hlc_resume_charging();
         shared_context.current_state = EvseState::PrepareCharging;
         if (shared_context.hlc_charging_terminate_pause == HlcTerminatePause::Terminate) {
             signal_slac_start(); // wake up SLAC as well

--- a/modules/EVSE/EvseManager/Charger.hpp
+++ b/modules/EVSE/EvseManager/Charger.hpp
@@ -167,6 +167,7 @@ public:
 
     sigslot::signal<> signal_hlc_stop_charging;
     sigslot::signal<> signal_hlc_pause_charging;
+    sigslot::signal<> signal_hlc_resume_charging;
     sigslot::signal<types::iso15118::EvseError> signal_hlc_error;
     sigslot::signal<> signal_hlc_plug_in_timeout;
 

--- a/modules/EVSE/EvseManager/EvseManager.cpp
+++ b/modules/EVSE/EvseManager/EvseManager.cpp
@@ -291,6 +291,7 @@ void EvseManager::ready() {
         // Ask HLC to stop charging session
         charger->signal_hlc_stop_charging.connect([this] { r_hlc[0]->call_stop_charging(true); });
         charger->signal_hlc_pause_charging.connect([this] { r_hlc[0]->call_pause_charging(true); });
+        charger->signal_hlc_resume_charging.connect([this] { r_hlc[0]->call_pause_charging(false); });
         charger->signal_hlc_plug_in_timeout.connect([this] {
             r_hlc[0]->call_authorization_response(types::authorization::AuthorizationStatus::Unknown,
                                                   types::authorization::CertificateStatus::NoCertificateAvailable);


### PR DESCRIPTION
When pause_charging is called, it signals the HLC stack to pause via signal_hlc_pause_charging (which calls r_hlc[0]->call_pause_charging(true)). However, resume_charging was not signaling HLC to resume, causing the V2G session to remain stuck in CurrentDemand at 0W.

This fix adds signal_hlc_resume_charging which calls r_hlc[0]->call_pause_charging(false) to properly resume HLC charging, mirroring the pause behavior.

Fixes: https://github.com/EVerest/everest-core/issues/1690

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

